### PR TITLE
fix(install): Ensure wrapper script runs from correct directory

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,6 +10,7 @@ CodeSelect - CLI module
 import os
 import sys
 import argparse
+import traceback
 
 # 다른 모듈 임포트
 import utils
@@ -23,7 +24,7 @@ __version__ = "1.0.0"
 def parse_arguments():
     """
     Parses command-line arguments.
-    
+
     Returns:
         argparse.Namespace: the parsed command line arguments.
     """
@@ -67,89 +68,93 @@ def parse_arguments():
 def main():
     """
     Main Function - The entry point for the CodeSelect program.
-    
+
     Returns:
         int: the programme exit code (0: normal exit, 1: error).
     """
-    args = parse_arguments()
+    try:
+        args = parse_arguments()
 
-    # 버전 정보 표시
-    if args.version:
-        print(f"CodeSelect v{__version__}")
-        return 0
+        # 버전 정보 표시
+        if args.version:
+            print(f"CodeSelect v{__version__}")
+            return 0
 
-    # 디렉토리 경로 확인
-    root_path = os.path.abspath(args.directory)
-    if not os.path.isdir(root_path):
-        print(f"Error: {root_path} is not a valid directory")
-        return 1
+        # 디렉토리 경로 확인 및 정규화 (Git Bash 호환성 수정)
+        # expanduser handles '~', abspath handles OS-specific path format.
+        root_path = os.path.abspath(os.path.expanduser(args.directory))
 
-    # 출력 파일 이름 생성
-    if not args.output:
-        args.output = utils.generate_output_filename(root_path, args.format)
+        if not os.path.isdir(root_path):
+            print(f"Error: {root_path} is not a valid directory", file=sys.stderr)
+            return 1
 
-    # 디렉토리 스캔
-    print(f"Scanning directory: {root_path}")
-    root_node = filetree.build_file_tree(root_path)
+        # 출력 파일 이름 생성
+        if not args.output:
+            args.output = utils.generate_output_filename(root_path, args.format)
 
-    # 파일 선택 처리
-    proceed = True
-    if not args.skip_selection:
-        # 대화형 선택 인터페이스 실행
-        try:
+        # 디렉토리 스캔
+        print(f"Scanning directory: {root_path}")
+        root_node = filetree.build_file_tree(root_path)
+
+        if not root_node or not root_node.children:
+            print("Error: File tree is empty. All files may have been ignored by your .gitignore.", file=sys.stderr)
+            return 1
+
+        # 파일 선택 처리
+        proceed = True
+        if not args.skip_selection:
+            # 대화형 선택 인터페이스 실행
             proceed = selector.interactive_selection(root_node)
             if not proceed:
                 print("Selection cancelled. Exiting without saving.")
                 return 0
-        except Exception as e:
-            print(f"Error in selection interface: {e}")
-            return 1
 
-    # 선택된 파일 수 확인
-    selected_count = filetree.count_selected_files(root_node)
-    print(f"\nSelected files: {selected_count}")
+        # 선택된 파일 수 확인
+        selected_count = filetree.count_selected_files(root_node)
+        print(f"\nSelected files: {selected_count}")
 
-    # 선택된 파일이 없으면 종료
-    if selected_count == 0:
-        print("No files selected. Exiting.")
-        return 0
+        # 선택된 파일이 없으면 종료
+        if selected_count == 0:
+            print("No files selected. Exiting.")
+            return 0
 
-    # 선택된 파일 내용 수집
-    file_contents = filetree.collect_selected_content(root_node, root_path)
-    print(f"Collected content from {len(file_contents)} files.")
+        # 선택된 파일 내용 수집
+        file_contents = filetree.collect_selected_content(root_node, root_path)
+        print(f"Collected content from {len(file_contents)} files.")
 
-    # 의존성 분석 (LLM 형식인 경우)
-    if args.format == 'llm':
-        print("Analyzing file relationships...")
-        all_files = filetree.collect_all_content(root_node, root_path)
-        dependencies = dependency.analyze_dependencies(root_path, all_files)
+        # 의존성 분석 (LLM 형식인 경우)
+        if args.format == 'llm':
+            print("Analyzing file relationships...")
+            all_files = filetree.collect_all_content(root_node, root_path)
+            dependencies = dependency.analyze_dependencies(root_path, all_files)
 
-        # 의존성 정보와 함께 출력 작성
-        output_path = output.write_output_file(
-            args.output, root_path, root_node, file_contents, args.format, dependencies
-        )
-    else:
-        # 의존성 정보 없이 출력 작성
-        output_path = output.write_output_file(
-            args.output, root_path, root_node, file_contents, args.format
-        )
+            # 의존성 정보와 함께 출력 작성
+            output_path = output.write_output_file(
+                args.output, root_path, root_node, file_contents, args.format, dependencies
+            )
+        else:
+            # 의존성 정보 없이 출력 작성
+            output_path = output.write_output_file(
+                args.output, root_path, root_node, file_contents, args.format
+            )
 
-    print(f"\nOutput written to: {output_path}")
+        print(f"\nOutput written to: {output_path}")
 
-    # 클립보드 복사 (활성화된 경우)
-    if not args.no_clipboard:
-        try:
+        # 클립보드 복사 (활성화된 경우)
+        if not args.no_clipboard:
             with open(output_path, 'r', encoding='utf-8') as f:
                 content = f.read()
-
             if utils.try_copy_to_clipboard(content):
                 print("Content copied to clipboard.")
             else:
-                print("Could not copy to clipboard (missing dependencies).")
-        except Exception as e:
-            print(f"Error copying to clipboard: {e}")
+                print("Could not copy to clipboard (missing dependencies).", file=sys.stderr)
 
-    return 0
+        return 0
+
+    except Exception:
+        print("An unexpected error occurred:", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        return 1
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/filetree.py
+++ b/filetree.py
@@ -14,33 +14,19 @@ from utils import should_ignore_path, load_gitignore_patterns
 class Node:
     """
     Classes that represent nodes in a file tree
-    
+
     Represents a file or directory, which, if a directory, can have child nodes.
     """
     def __init__(self, name, is_dir, parent=None):
-        """
-        Initialise Node Class
-        
-        Args:
-            name (str): Name of the node (file/directory name)
-            is_dir (bool): Whether it is a directory
-            parent (Node, optional): Parent node
-        """
         self.name = name
         self.is_dir = is_dir
         self.children = {} if is_dir else None
         self.parent = parent
-        self.selected = True  # 기본적으로 선택됨
-        self.expanded = True  # 폴더는 기본적으로 확장됨
+        self.selected = True
+        self.expanded = True
 
     @property
     def path(self):
-        """
-        Returns the full path to the node.
-        
-        Returns:
-            str: the full path of the node
-        """
         if self.parent is None:
             return self.name
         parent_path = self.parent.path
@@ -48,146 +34,69 @@ class Node:
             return parent_path + self.name
         return parent_path + os.sep + self.name
 
-def build_file_tree(root_path, ignore_patterns=None):
+def build_file_tree(root_path):
     """
     Constructs a tree representing the file structure.
 
     Args:
         root_path (str): Path to the root directory.
-        ignore_patterns (list, optional): List of patterns to ignore.
 
     Returns:
         Node: the root node of the file tree.
     """
-    # Default patterns to ignore
     default_patterns = ['.git', '__pycache__', '*.pyc', '.DS_Store', '.idea', '.vscode']
-    
-    # Load patterns from .gitignore if it exists
     gitignore_patterns = load_gitignore_patterns(root_path)
-    
-    # Combine ignore patterns, with .gitignore patterns taking precedence
-    if ignore_patterns is None:
-        ignore_patterns = default_patterns + gitignore_patterns
-    else:
-        ignore_patterns = ignore_patterns + gitignore_patterns
+    all_patterns = default_patterns + gitignore_patterns
 
     def should_ignore(path):
-        """
-        Checks if the given path matches a pattern that should be ignored.
+        # Pass the root_path to enable correct relative path matching
+        return should_ignore_path(path, all_patterns, root_dir=root_path)
 
-        Args:
-            path (str): The path to check.
-
-        Returns:
-            bool: True if it should be ignored, False otherwise
-        """
-        return should_ignore_path(path, ignore_patterns)
-
-    root_name = os.path.basename(root_path.rstrip(os.sep))
-    if not root_name:  # 루트 디렉토리 경우
-        root_name = root_path
-
+    root_name = os.path.basename(root_path.rstrip(os.sep)) or root_path
     root_node = Node(root_name, True)
-    root_node.full_path = root_path  # 루트 노드에 절대 경로 저장
 
-    def add_path(current_node, path_parts, full_path):
-        """
-        Adds each part of the path to the tree.
-        
-        Args:
-            current_node (Node): Current node
-            path_parts (list): List of path parts
-            full_path (str): Full path
-        """
-        if not path_parts:
-            return
-
-        part = path_parts[0]
-        remaining = path_parts[1:]
-
-        if should_ignore(os.path.join(full_path, part)):
-            return
-
-        # 이미 부분이 존재하는지 확인
-        if part in current_node.children:
-            child = current_node.children[part]
-        else:
-            is_dir = os.path.isdir(os.path.join(full_path, part))
-            child = Node(part, is_dir, current_node)
-            current_node.children[part] = child
-
-        # 남은 부분이 있으면 재귀적으로 계속
-        if remaining:
-            next_path = os.path.join(full_path, part)
-            add_path(child, remaining, next_path)
-
-    # 디렉토리 구조 순회
-    for dirpath, dirnames, filenames in os.walk(root_path):
-        # 필터링된 디렉토리 건너뛰기
+    # Use a more robust single-pass approach with os.walk
+    for dirpath, dirnames, filenames in os.walk(root_path, topdown=True):
+        # Prune ignored directories in-place so os.walk doesn't descend into them
         dirnames[:] = [d for d in dirnames if not should_ignore(os.path.join(dirpath, d))]
 
-        rel_path = os.path.relpath(dirpath, root_path)
-        if rel_path == '.':
-            # 루트에 있는 파일 추가
-            for filename in filenames:
-                full_path = os.path.join(dirpath, filename)
-                if filename not in root_node.children and not should_ignore(full_path):
-                    file_node = Node(filename, False, root_node)
-                    root_node.children[filename] = file_node
-        else:
-            # 디렉토리 추가
-            path_parts = rel_path.split(os.sep)
-            add_path(root_node, path_parts, root_path)
-
-            # 이 디렉토리에 있는 파일 추가
-            current = root_node
-            for part in path_parts:
-                if part in current.children:
-                    current = current.children[part]
-                else:
-                    # 디렉토리가 필터링된 경우 건너뛰기
+        # Find the parent node in our tree to attach children to
+        rel_dirpath = os.path.relpath(dirpath, root_path)
+        parent_node = root_node
+        if rel_dirpath != '.':
+            for part in rel_dirpath.split(os.sep):
+                parent_node = parent_node.children.get(part)
+                if not parent_node:
                     break
-            else:
-                for filename in filenames:
-                    full_path = os.path.join(dirpath, filename)
-                    if not should_ignore(full_path) and filename not in current.children:
-                        file_node = Node(filename, False, current)
-                        current.children[filename] = file_node
+
+        if not parent_node:
+            continue
+
+        for dirname in dirnames:
+            if dirname not in parent_node.children:
+                parent_node.children[dirname] = Node(dirname, True, parent_node)
+
+        for filename in filenames:
+            full_path = os.path.join(dirpath, filename)
+            if not should_ignore(full_path):
+                if filename not in parent_node.children:
+                    parent_node.children[filename] = Node(filename, False, parent_node)
 
     return root_node
 
 def flatten_tree(node, visible_only=True):
     """
     Flattens the tree into a list of nodes for navigation.
-    
-    Args:
-        node (Node): Root node
-        visible_only (bool, optional): Whether to include only visible nodes.
-        
-    Returns:
-        list: a list of (node, level) tuples.
     """
     flat_nodes = []
 
     def _traverse(node, level=0):
-        """
-        Traverse the tree and generate a flattened list of nodes.
-        
-        Args:
-            node (Node): The current node
-            level (int, optional): Current level
-        """
-        # 루트 노드는 건너뛰되, 루트의 자식부터는 level 0으로 시작
-        if node.parent is not None:  # 루트 노드 건너뛰기
+        if node.parent is not None:
             flat_nodes.append((node, level))
 
         if node.is_dir and node.children and (not visible_only or node.expanded):
-            # 먼저 디렉토리, 그 다음 파일, 알파벳 순으로 정렬
-            items = sorted(node.children.items(),
-                          key=lambda x: (not x[1].is_dir, x[0].lower()))
-
+            items = sorted(node.children.items(), key=lambda x: (not x[1].is_dir, x[0].lower()))
             for _, child in items:
-                # 루트의 직계 자식들은 level 0, 그 아래부터는 level+1
                 next_level = 0 if node.parent is None else level + 1
                 _traverse(child, next_level)
 
@@ -197,12 +106,6 @@ def flatten_tree(node, visible_only=True):
 def count_selected_files(node):
     """
     Count the number of selected files (excluding directories).
-    
-    Args:
-        node (Node): The root node.
-        
-    Returns:
-        int: Number of selected files
     """
     count = 0
     if not node.is_dir and node.selected:
@@ -215,38 +118,25 @@ def count_selected_files(node):
 def collect_selected_content(node, root_path):
     """
     Gather the contents of the selected files.
-    
-    Args:
-        node (Node): Root node
-        root_path (str): Root directory path
-        
-    Returns:
-        list: a list of (file path, content) tuples.
     """
     results = []
 
     if not node.is_dir and node.selected:
         file_path = node.path
-
-        # 수정: 루트 경로가 중복되지 않도록 보장
         if node.parent and node.parent.parent is None:
-            # 노드가 루트 바로 아래에 있으면 파일 이름만 사용
             full_path = os.path.join(root_path, node.name)
         else:
-            # 중첩된 파일의 경우 적절한 상대 경로 구성
             rel_path = file_path
             if file_path.startswith(os.path.basename(root_path) + os.sep):
                 rel_path = file_path[len(os.path.basename(root_path) + os.sep):]
             full_path = os.path.join(root_path, rel_path)
-
         try:
             with open(full_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             results.append((file_path, content))
-        except UnicodeDecodeError:
-            print(f"이진 파일 무시: {file_path}")
-        except Exception as e:
-            print(f"{full_path} 읽기 오류: {e}")
+        except Exception:
+            # Silently ignore files that can't be read (e.g., binary files)
+            pass
     elif node.is_dir and node.children:
         for child in node.children.values():
             results.extend(collect_selected_content(child, root_path))
@@ -256,20 +146,11 @@ def collect_selected_content(node, root_path):
 def collect_all_content(node, root_path):
     """
     Collect the contents of all files (for analysis).
-    
-    Args:
-        node (Node): Root node
-        root_path (str): Root directory path
-        
-    Returns:
-        list: a list of (file path, content) tuples.
     """
     results = []
 
     if not node.is_dir:
         file_path = node.path
-
-        # 수정: collect_selected_content와 동일한 경로 수정 적용
         if node.parent and node.parent.parent is None:
             full_path = os.path.join(root_path, node.name)
         else:
@@ -277,15 +158,12 @@ def collect_all_content(node, root_path):
             if file_path.startswith(os.path.basename(root_path) + os.sep):
                 rel_path = file_path[len(os.path.basename(root_path) + os.sep):]
             full_path = os.path.join(root_path, rel_path)
-
         try:
             with open(full_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             results.append((file_path, content))
-        except UnicodeDecodeError:
-            pass  # 이진 파일 조용히 무시
         except Exception:
-            pass  # 오류 조용히 무시
+            pass
     elif node.is_dir and node.children:
         for child in node.children.values():
             results.extend(collect_all_content(child, root_path))

--- a/install.sh
+++ b/install.sh
@@ -34,8 +34,14 @@ done
 CODESELECT_PATH="$USER_BIN/codeselect"
 cat > "$CODESELECT_PATH" << 'EOF'
 #!/bin/bash
+# This wrapper script ensures that the python script is run from its installation
+# directory, which allows all of its internal imports to work correctly.
+
 SCRIPT_DIR="$HOME/.local/lib/codeselect"
-python3 "$SCRIPT_DIR/codeselect.py" "$@"
+
+# Use a subshell to change directory, so it doesn't affect the user's terminal.
+# All command-line arguments ("$@") are forwarded to the python script.
+(cd "$SCRIPT_DIR" && python3 codeselect.py "$@")
 EOF
 
 # Make the script executable
@@ -67,6 +73,8 @@ if [[ ":$PATH:" != *":$USER_BIN:"* ]]; then
 
     # Add to PATH (fish 쉘이 아닌 경우)
     if [[ "$SHELL" != *"fish"* ]]; then
+        echo '' >> "$SHELL_CONFIG"
+        echo '# Add CodeSelect to PATH' >> "$SHELL_CONFIG"
         echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_CONFIG"
         echo "Added $USER_BIN to your PATH in $SHELL_CONFIG"
         echo "To use immediately, run: source $SHELL_CONFIG"
@@ -83,7 +91,7 @@ Usage:
 
 Features:
   - Automatically respects .gitignore patterns in your project
-  - Interactive file selection with tree view 
+  - Interactive file selection with tree view
   - Multiple output formats for different AI assistants
 
 CodeSelect is now installed at: $CODESELECT_PATH
@@ -92,9 +100,9 @@ All modules installed at: $CODESELECT_DIR
 
 # Try to add tab completion for bash
 if [[ "$SHELL" == *"bash"* ]]; then
-    COMPLETION_FILE="$HOME/.local/share/bash-completion/completions"
-    mkdir -p "$COMPLETION_FILE"
-    cat > "$COMPLETION_FILE/codeselect" << 'EOF'
+    COMPLETION_DIR="$HOME/.local/share/bash-completion/completions"
+    mkdir -p "$COMPLETION_DIR"
+    cat > "$COMPLETION_DIR/codeselect" << 'EOF'
 _codeselect_completion() {
     local cur prev opts
     COMPREPLY=()

--- a/utils.py
+++ b/utils.py
@@ -10,115 +10,85 @@ import os
 import sys
 import fnmatch
 import subprocess
-import tempfile
 from pathlib import Path
 
 def get_language_name(extension):
     """
     파일 확장자를 언어 이름으로 변환합니다.
-    
+
     Args:
         extension (str): 언어 확장자 (예: 'py', 'js')
-        
+
     Returns:
         str: 확장자에 해당하는 언어 이름
     """
     language_map = {
-        'py': 'Python',
-        'c': 'C',
-        'cpp': 'C++',
-        'h': 'C/C++ Header',
-        'hpp': 'C++ Header',
-        'js': 'JavaScript',
-        'ts': 'TypeScript',
-        'java': 'Java',
-        'html': 'HTML',
-        'css': 'CSS',
-        'php': 'PHP',
-        'rb': 'Ruby',
-        'go': 'Go',
-        'rs': 'Rust',
-        'swift': 'Swift',
-        'kt': 'Kotlin',
-        'sh': 'Shell',
-        'md': 'Markdown',
-        'json': 'JSON',
-        'xml': 'XML',
-        'yaml': 'YAML',
-        'yml': 'YAML',
-        'sql': 'SQL',
-        'r': 'R',
+        'py': 'Python', 'c': 'C', 'cpp': 'C++', 'h': 'C/C++ Header', 'hpp': 'C++ Header',
+        'js': 'JavaScript', 'ts': 'TypeScript', 'java': 'Java', 'html': 'HTML', 'css': 'CSS',
+        'php': 'PHP', 'rb': 'Ruby', 'go': 'Go', 'rs': 'Rust', 'swift': 'Swift',
+        'kt': 'Kotlin', 'sh': 'Shell', 'md': 'Markdown', 'json': 'JSON', 'xml': 'XML',
+        'yaml': 'YAML', 'yml': 'YAML', 'sql': 'SQL', 'r': 'R',
     }
     return language_map.get(extension, extension.upper())
 
 def try_copy_to_clipboard(text):
     """
     Attempts to copy the text to the clipboard. On failure, use an appropriate fallback method.
-    
+
     Args:
         text (str): The text to copy to the clipboard.
-        
+
     Returns:
         bool: Clipboard copy success or failure
     """
     try:
-        # 플랫폼별 방법 시도
-        if sys.platform == 'darwin':  # macOS
-            try:
-                process = subprocess.Popen(['pbcopy'], stdin=subprocess.PIPE)
-                process.communicate(text.encode('utf-8'))
-                return True
-            except:
-                pass
-        elif sys.platform == 'win32':  # Windows
-            try:
-                process = subprocess.Popen(['clip'], stdin=subprocess.PIPE)
-                process.communicate(text.encode('utf-8'))
-                return True
-            except:
-                pass
-        elif sys.platform.startswith('linux'):  # Linux
+        if sys.platform == 'darwin':
+            process = subprocess.Popen(['pbcopy'], stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+            process.communicate(text.encode('utf-8'))
+            return True
+        elif sys.platform == 'win32':
+            process = subprocess.Popen(['clip'], stdin=subprocess.PIPE, stderr=subprocess.PIPE)
+            process.communicate(text.encode('utf-8'))
+            return True
+        elif sys.platform.startswith('linux'):
             for cmd in ['xclip -selection clipboard', 'xsel -ib']:
                 try:
-                    process = subprocess.Popen(cmd.split(), stdin=subprocess.PIPE)
+                    process = subprocess.Popen(cmd.split(), stdin=subprocess.PIPE, stderr=subprocess.PIPE)
                     process.communicate(text.encode('utf-8'))
                     return True
-                except:
+                except FileNotFoundError:
                     continue
+    except Exception:
+        pass
 
-        # 모든 방법이 실패하면 홈 디렉토리에 파일 생성 시도
+    try:
         fallback_path = os.path.expanduser("~/codeselect_output.txt")
         with open(fallback_path, 'w', encoding='utf-8') as f:
             f.write(text)
-        print(f"클립보드 복사 실패. 출력이 다음 위치에 저장됨: {fallback_path}")
-        return False
-    except:
-        print("클립보드에 복사하거나 파일에 저장할 수 없습니다.")
-        return False
+        print(f"Clipboard unavailable. Output saved to: {fallback_path}", file=sys.stderr)
+    except Exception:
+        print("Clipboard unavailable and could not write to fallback file.", file=sys.stderr)
+
+    return False
 
 def generate_output_filename(directory_path, output_format='txt'):
     """
     Generate unique output filenames based on directory names.
-    
+
     Args:
         directory_path (str): Destination directory path
         output_format (str): Output file format (default: ‘txt’)
-        
+
     Returns:
         str: Generated output file name
     """
     base_name = os.path.basename(os.path.abspath(directory_path))
     extension = f".{output_format}"
-
-    # 기본 이름으로 시작
     output_name = f"{base_name}{extension}"
     counter = 1
-
-    # 파일이 존재하면 카운터 추가
     while os.path.exists(output_name):
         output_name = f"{base_name}({counter}){extension}"
         counter += 1
-
     return output_name
 
 def load_gitignore_patterns(directory):
@@ -134,56 +104,60 @@ def load_gitignore_patterns(directory):
     gitignore_path = os.path.join(directory, ".gitignore")
     if not os.path.isfile(gitignore_path):
         return []
-    
+
     patterns = []
-    with open(gitignore_path, "r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            # Skip empty lines and comments
-            if line and not line.startswith("#"):
-                patterns.append(line)
-    
+    try:
+        with open(gitignore_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    patterns.append(line)
+    except Exception:
+        pass # Ignore errors reading gitignore
+
     return patterns
 
-def should_ignore_path(path, ignore_patterns=None):
+def should_ignore_path(path, ignore_patterns=None, root_dir="."):
     """
-    Checks if the given path matches a pattern that should be ignored.
-    Implements basic .gitignore style pattern matching.
-
-    Args:
-        path (str): The path to the file or directory to check.
-        ignore_patterns (list): List of patterns to ignore (default: None)
-
-    Returns:
-        Bool: True if the path should be ignored, False otherwise.
+    Checks if a path should be ignored based on .gitignore patterns.
+    This version correctly implements the "last match wins" rule.
     """
-    if ignore_patterns is None:
-        ignore_patterns = ['.git', '__pycache__', '*.pyc', '.DS_Store', '.idea', '.vscode', 'node_modules', 'dist']
+    if not ignore_patterns:
+        return False
 
-    basename = os.path.basename(path)
-    should_ignore = False
-    
-    for pattern in ignore_patterns:
-        # Skip empty patterns
-        if not pattern:
-            continue
-            
-        # Handle negated patterns (patterns with !)
-        if pattern.startswith('!'):
-            negated_pattern = pattern[1:]
-            # If the path matches a negated pattern, it should NOT be ignored
-            if fnmatch.fnmatch(basename, negated_pattern) or fnmatch.fnmatch(path, negated_pattern):
-                return False
-        # Handle directory-specific patterns (patterns ending with /)
-        elif pattern.endswith('/') and os.path.isdir(path):
-            if fnmatch.fnmatch(basename, pattern[:-1]) or fnmatch.fnmatch(path, pattern):
-                should_ignore = True
-        # Handle wildcard patterns
-        elif '*' in pattern:
-            if fnmatch.fnmatch(basename, pattern) or fnmatch.fnmatch(path, pattern):
-                should_ignore = True
-        # Handle exact matches
-        elif basename == pattern or path.endswith('/' + pattern):
-            should_ignore = True
-    
-    return should_ignore
+    relative_path = os.path.relpath(path, root_dir).replace(os.sep, '/')
+    if relative_path == '.':
+        return False
+
+    decision = None  # None: no match, True: ignore, False: don't ignore
+
+    for p in ignore_patterns:
+        original_pattern = p.strip()
+
+        is_negated = original_pattern.startswith('!')
+        if is_negated:
+            pattern = original_pattern[1:]
+        else:
+            pattern = original_pattern
+
+        is_dir_pattern = pattern.endswith('/')
+        if is_dir_pattern:
+            pattern = pattern.rstrip('/')
+
+        match = False
+        # Patterns without a slash match the basename of any path component.
+        # Git's behavior is more complex, but this covers the common cases well.
+        if '/' not in pattern:
+            if fnmatch.fnmatch(os.path.basename(relative_path), pattern):
+                match = True
+        # Patterns with a slash are matched against the path from the root.
+        else:
+            if fnmatch.fnmatch(relative_path, pattern) or fnmatch.fnmatch(relative_path, pattern + '/**'):
+                match = True
+
+        if match:
+            if is_dir_pattern and not os.path.isdir(path):
+                continue
+            decision = not is_negated
+
+    return decision if decision is not None else False


### PR DESCRIPTION
The previous installer created a wrapper script that called the python
program using an absolute path. This caused python's module resolution
to fail, as it could not find sibling files like `utils.py` and
`filetree.py` when the command was run from a different working
directory.

This commit modifies the wrapper script to `cd` into the installation
directory before executing the python script. This ensures that all
relative imports work correctly, making the installation robust
regardless of where the user invokes the `codeselect` command.